### PR TITLE
Fix docs on fields nodrop and norent.   For both fields 0 means true …

### DIFF
--- a/docs/categories/items/items.md
+++ b/docs/categories/items/items.md
@@ -99,8 +99,8 @@
 | herosforgemodel | int | Hero's Forge Model |
 | maxcharges | int | Maximum Charges \(-1 for infinite\). |
 | mr | int | Magic Resistance: -128 to 127 |
-| nodrop | int | No Drop: 0 = False, 1 = True |
-| norent | int | No Rent: 0 = False, 1 = True |
+| nodrop | int | No Drop: 0 = True, 1 = False |
+| norent | int | No Rent: 0 = True, 1 = False |
 | pendingloreflag | tinyint | Pending Lore Flag: 0 = False, 1 = True |
 | pr | int | Poison Resistance: -128 to 127 |
 | procrate | int | Proc Rate: 0 = 100%, 50 = 150%, 100 = 200% |


### PR DESCRIPTION
Fix docs on fields nodrop and norent. For both fields 0 means true ……(item cannot be dropped, item expires)

This has always seemed backwards to me, but the docs need to reflect reality.